### PR TITLE
fix: :bug: MySQLの文字化け解消

### DIFF
--- a/mysql/init/20_insert.sql
+++ b/mysql/init/20_insert.sql
@@ -1,4 +1,6 @@
 USE vulshop;
+SET CHARACTER_SET_CLIENT = utf8;
+SET CHARACTER_SET_CONNECTION = utf8;
 INSERT INTO products
     (name, price, description, stock, created_at, updated_at, active)
 VALUES


### PR DESCRIPTION
## why

MySQLの初期化時の挿入箇所で、文字コードを指定していなかった

Closes #10

解消後
![image](https://user-images.githubusercontent.com/70436490/183273295-4deeb946-c633-44e8-b6a0-3ef156eca4fe.png)
